### PR TITLE
change entory point WinMain to main

### DIFF
--- a/DxLibPp/DxLibPp.cpp
+++ b/DxLibPp/DxLibPp.cpp
@@ -180,9 +180,3 @@ void DxLibPp::global::resolve_attachment() {
 bool DxLibPp::system::update() {
     return ScreenFlip() != -1 && ProcessMessage() != -1 && ClearDrawScreen() != -1;
 }
-
-int main();
-
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
-    return main();
-}

--- a/DxLibPp/DxLibPp.hpp
+++ b/DxLibPp/DxLibPp.hpp
@@ -8,6 +8,10 @@
 #include <optional>
 #include <functional>
 
+#ifdef _MSC_VER
+#    pragma comment(linker, "/subsystem:windows /ENTRY:mainCRTStartup")
+#endif
+
 namespace DxLibPp {
 
 template<typename T>


### PR DESCRIPTION
他ファイルにWinMainの本体を書かなくてもmain関数から開始できるように修正。